### PR TITLE
Fix stacking observer, skill label, and unmet/augmented multi-match

### DIFF
--- a/content.js
+++ b/content.js
@@ -28,10 +28,10 @@ function parseItemData(itemElement) {
     .map((prop) => prop.textContent.trim())
     .join("\n");
 
-  // Extract skill properties as implicit mods
+  // Extract skill gem properties
   const skillProperties = propertyElements
     .filter((prop) => prop.classList.contains("skill")) // Include only skill properties
-    .map((prop) => `${prop.textContent.trim()} (implicit)`)
+    .map((prop) => prop.textContent.trim())
     .join("\n");
 
   // Extract requirements dynamically
@@ -97,8 +97,12 @@ function parseItemData(itemElement) {
     .join("\n");
 
   // Extract unmet and augmented
-  const unmet = itemElement.querySelector(".unmet")?.textContent.trim() || "";
-  const augmented = itemElement.querySelector(".augmented span")?.textContent.trim() || "";
+  const unmet = Array.from(itemElement.querySelectorAll(".unmet"))
+    .map((el) => el.textContent.trim())
+    .join("\n");
+  const augmented = Array.from(itemElement.querySelectorAll(".augmented span"))
+    .map((el) => el.textContent.trim())
+    .join("\n");
 
   // Construct the formatted text
   const sections = [
@@ -222,14 +226,20 @@ function copyToClipboard(text) {
 }
 
 // Main observer logic
-const mainObserver = new MutationObserver((mutations, obs) => {
+let resultSetObserver = null;
+let observedResultSet = null;
+
+const mainObserver = new MutationObserver(() => {
   const resultSet = document.querySelector('.resultset');
-  if (resultSet) {
+  if (resultSet && resultSet !== observedResultSet) {
     //console.log("Result set found:", resultSet); // for debug
 
-    //obs.disconnect();
+    if (resultSetObserver) {
+      resultSetObserver.disconnect();
+    }
 
-    const resultSetObserver = new MutationObserver(() => {
+    observedResultSet = resultSet;
+    resultSetObserver = new MutationObserver(() => {
       addExportButtons();
     });
 


### PR DESCRIPTION
## Summary

- **Observer leak**: `mainObserver` was creating a new inner `resultSetObserver` every time the DOM mutated without disconnecting the old one, causing stacked duplicate observers and wasted CPU. Now tracks the observed resultset and replaces the observer when a new one is found.
- **Skill label**: Skill gem properties were incorrectly tagged as `(implicit)`, which could cause wrong PoB imports. Removed the label entirely.
- **Unmet / augmented**: `querySelector` (first match only) replaced with `querySelectorAll` so all unmet requirements and augmented modifiers are captured.

## Test plan
- [ ] Load a skill gem item on the trade site — Export button appears, no `(implicit)` suffix on skill properties
- [ ] Load an item with multiple unmet requirements — all are included in the exported text
- [ ] Navigate between result pages multiple times — no duplicate Export buttons, CPU stays flat

🤖 Generated with [Claude Code](https://claude.com/claude-code)